### PR TITLE
Remove directory and version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
     "CI",
     "Code coverage"
   ],
-  "version": "0.1.3",
   "license": "MIT",
   "authors": [
     {
@@ -20,5 +19,5 @@
   "require": {
     "php": ">=5.5.0"
   },
-  "bin": ["bin/", "bin/coverage-check"]
+  "bin": ["bin/coverage-check"]
 }


### PR DESCRIPTION
The [version](https://getcomposer.org/doc/04-schema.md#version) should not be included.

More importantly, listing `bin/` as a binary causes a symlink to a folder in user's bin (i.e. `./vendor/bin/bin`).
https://getcomposer.org/doc/articles/vendor-binaries.md