### PR TITLE
Allow coverage-check use a non-default PHP version

### DIFF
--- a/bin/coverage-check
+++ b/bin/coverage-check
@@ -1,3 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env php
+<?php
 
-php vendor/rregeer/phpunit-coverage-check/coverage-check.php $1 $2
+include 'vendor/rregeer/phpunit-coverage-check/coverage-check.php';


### PR DESCRIPTION
This lets you run coverage-check with a different PHP version without having to set it as the default:

    php7.2 vendor/bin/coverage-check

