### PR TITLE
bin: Use an explicit inclusion and fail if missing

### DIFF
--- a/bin/coverage-check
+++ b/bin/coverage-check
@@ -1,4 +1,4 @@
 #!/usr/bin/env php
 <?php
 
-include 'vendor/rregeer/phpunit-coverage-check/coverage-check.php';
+require dirname( __DIR__ ) . '/coverage-check.php';


### PR DESCRIPTION
* Use an explicit inclusion instead of depending on (and exposing to) a certain include dir configuration.
* Use 'require' instead of 'include' so that absence results in a hard failure instead of a warning.