### PR TITLE
Check conditionals instead of elements

### DIFF
--- a/coverage-check.php
+++ b/coverage-check.php
@@ -42,16 +42,16 @@ $onlyEchoPercentage = isset($argv[3]) && $argv[3] === '--only-percentage';
 $inputFile = $argv[1];
 $percentage = min(100, max(0, (float) $argv[2]));
 
-$elements = 0;
-$coveredElements = 0;
+$conditionals = 0;
+$coveredConditionals = 0;
 $statements = 0;
 $coveredstatements = 0;
 $methods = 0;
 $coveredmethods = 0;
 
 foreach (loadMetrics($inputFile) as $metric) {
-    $elements += (int) $metric['elements'];
-    $coveredElements += (int) $metric['coveredelements'];
+    $conditionals += (int) $metric['conditionals'];
+    $coveredConditionals += (int) $metric['coveredconditionals'];
     $statements += (int) $metric['statements'];
     $coveredstatements += (int) $metric['coveredstatements'];
     $methods += (int) $metric['methods'];
@@ -59,8 +59,8 @@ foreach (loadMetrics($inputFile) as $metric) {
 }
 
 // See calculation: https://confluence.atlassian.com/pages/viewpage.action?pageId=79986990
-$coveredMetrics = $coveredstatements + $coveredmethods + $coveredElements;
-$totalMetrics = $statements + $methods + $elements;
+$coveredMetrics = $coveredstatements + $coveredmethods + $coveredConditionals;
+$totalMetrics = $statements + $methods + $conditionals;
 
 if ($totalMetrics === 0) {
     printStatus('Insufficient data for calculation. Please add more code.', STATUS_ERROR);


### PR DESCRIPTION
Per https://confluence.atlassian.com/pages/viewpage.action?pageId=79986990 which is already referenced for the calculation:

    So in order to calculate the Total Percentage Coverage metric using data from an XML report you have to use the following equation:

    TPC = (coveredconditionals + coveredstatements + coveredmethods) / (conditionals + statements + methods)

Using elements is incorrect because, as that page notes, "elements" is conditionals + statements, which means the previous calculation would double-count statements.